### PR TITLE
localize menu tooltip text before wrapping

### DIFF
--- a/libtooltipmenu/ca.ancilla.libtooltipmenu/TooltipOptionMenu.zsc
+++ b/libtooltipmenu/ca.ancilla.libtooltipmenu/TooltipOptionMenu.zsc
@@ -49,8 +49,7 @@ class TF_Tooltip : Object ui {
     // Nominal width is the maximum width of the tooltip based on configuration
     // in the MENUDEF.
     let nominal_width = virtual_width * self.w;
-    let localtext = Stringtable.localize(self.text);
-    let lines = self.font.BreakLines(localtext, nominal_width);
+    let lines = self.font.BreakLines(text, nominal_width);
 
     // Calculate the real width of the tooltip. This may be less than the
     // nominal width if it's a short one-liner. This is still in virtual screen
@@ -174,10 +173,11 @@ class TF_TooltipOptionMenu : OptionMenu {
 
   void AddTooltip(TF_Tooltip settings, uint first, uint last, string tooltip) {
     if (first < 0) ThrowAbortException("Tooltip must have at least one menu item preceding it!");
+	let localtooltip = Stringtable.localize(tooltip);
     let tt = AppendableTooltip(first, last);
     if (tt) {
       // Existing tooltip that we're just appending to.
-      tt.text = tt.text .. "\n" .. tooltip;
+      tt.text = tt.text .. "\n" .. localtooltip;
       return;
     }
     // No existing tooltip for these menu entries, create a new one.
@@ -185,7 +185,7 @@ class TF_TooltipOptionMenu : OptionMenu {
     tt.CopyFrom(settings);
     tt.first = first;
     tt.last = last;
-    tt.text = tooltip;
+    tt.text = localtooltip;
     tooltips.push(tt);
   }
 

--- a/libtooltipmenu/ca.ancilla.libtooltipmenu/TooltipOptionMenu.zsc
+++ b/libtooltipmenu/ca.ancilla.libtooltipmenu/TooltipOptionMenu.zsc
@@ -49,7 +49,8 @@ class TF_Tooltip : Object ui {
     // Nominal width is the maximum width of the tooltip based on configuration
     // in the MENUDEF.
     let nominal_width = virtual_width * self.w;
-    let lines = self.font.BreakLines(self.text, nominal_width);
+    let localtext = Stringtable.localize(self.text);
+    let lines = self.font.BreakLines(localtext, nominal_width);
 
     // Calculate the real width of the tooltip. This may be less than the
     // nominal width if it's a short one-liner. This is still in virtual screen


### PR DESCRIPTION
this commit fixes an issue where the width of the tooltip would match the length of the LANGUAGE keyword, instead of the localized text. this would cause multiple issues, like the tooltip width being incorrect, or the tooltip incorrectly displaying the keyword instead of the localized text if the keyword was too long to fit in one line.

edit: my original commit didn't work if multiple tooltips were assigned to a single menu item. the latest commit, fbaac340608a52396025fada765719588834a8fb addresses this.