### PR TITLE
Added Samsara Reincarnation compatiblity to Gun Bonsai

### DIFF
--- a/gun-bonsai/BONSAIRC
+++ b/gun-bonsai/BONSAIRC
@@ -190,7 +190,7 @@ ifdef Macheterang DehackedWeaponGiver { unregister TFLV_Upgrade_Bandoliers; }
 ifdef IsSamsaraClass {
 	# Remove a couple of upgrades that have issues in Samsara.
 	# Player upgrades
-	unregister TFLV_Upgrade_AmmoLeech TFLV_Upgrade_ArmourLeech TFLV_Upgrade_Bandoliers TFLV_Upgrade_LifeLeech TFLV_Upgrade_Juggler TFLV_Upgrade_PiercingShots;
+	unregister TFLV_Upgrade_AmmoLeech TFLV_Upgrade_ArmourLeech TFLV_Upgrade_Bandoliers TFLV_Upgrade_LifeLeech TFLV_Upgrade_Juggler;
 	# Generic weapon upgrades
 	unregister TFLV_Upgrade_PiercingShots;
 	
@@ -199,6 +199,7 @@ ifdef IsSamsaraClass {
 	type DescentWeaponPadUp: IGNORE;
 	type DescentWeaponPadDown: IGNORE;
 	type DescentLaser: IGNORE;
+	type DescentSuperLaser: IGNORE;
 	type DescentVulcan: IGNORE;
 	type DescentGauss: IGNORE;
 	type DescentSpreadFire: IGNORE;

--- a/gun-bonsai/BONSAIRC
+++ b/gun-bonsai/BONSAIRC
@@ -194,6 +194,8 @@ ifdef IsSamsaraClass {
 	# Generic weapon upgrades
 	unregister TFLV_Upgrade_PiercingShots;
 	
+	type Duke3D_MightyStomp: IGNORE;
+	
 	# Mostly fixes the Descent weapons.
 	type DescentWeapon: PROJECTILE;
 	type DescentWeaponPadUp: IGNORE;

--- a/gun-bonsai/BONSAIRC
+++ b/gun-bonsai/BONSAIRC
@@ -185,3 +185,26 @@ ifdef PB_Shotgun {
 
 # Trailblazer and Dehacked Defence
 ifdef Macheterang DehackedWeaponGiver { unregister TFLV_Upgrade_Bandoliers; }
+
+# Samsara Reincarnation
+ifdef IsSamsaraClass {
+	# Remove a couple of upgrades that have issues in Samsara.
+	# Player upgrades
+	unregister TFLV_Upgrade_AmmoLeech TFLV_Upgrade_ArmourLeech TFLV_Upgrade_Bandoliers TFLV_Upgrade_LifeLeech TFLV_Upgrade_Juggler TFLV_Upgrade_PiercingShots;
+	# Generic weapon upgrades
+	unregister TFLV_Upgrade_PiercingShots;
+	
+	# Mostly fixes the Descent weapons.
+	type DescentWeapon: PROJECTILE;
+	type DescentWeaponPadUp: IGNORE;
+	type DescentWeaponPadDown: IGNORE;
+	type DescentLaser: IGNORE;
+	type DescentVulcan: IGNORE;
+	type DescentGauss: IGNORE;
+	type DescentSpreadFire: IGNORE;
+	type DescentFusion: IGNORE;
+	type DescentHelix: IGNORE;
+	type DescentOmega: IGNORE;
+	type DescentPlasma: IGNORE;
+	type DescentPhoenix: IGNORE;
+}


### PR DESCRIPTION
Even though I could already do this by adding the BONSAIRC lump to Samsara Reincarnation, I wanted to add the lumps into Gun Bonsai itself so that the load order for both the gameplay mods wouldn't matter. There were some upgrades that didn't play nicely with Samsara, and even though there might be minor issues, this pull request should solve most of the problems that I've encountered when playing with Gun Bonsai.

Feel free to let me know if there's something that I've missed or messed up on.